### PR TITLE
Adds `html_root` attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "same-file"
-version = "0.1.3"  #:version
+version = "0.1.3"  #:version remember to update html_root_url
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
 A simple crate for determining whether two file paths point to the same file.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "same-file"
-version = "0.1.3"  #:version remember to update html_root_url
+version = "0.1.3"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
 A simple crate for determining whether two file paths point to the same file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ See [`examples/is_stderr.rs`] for a runnable example and compare the output of:
 
 */
 
+#![doc(html_root_url = "https://docs.rs/same-file/1.0.0")]
 #![deny(missing_docs)]
 
 #[cfg(windows)]


### PR DESCRIPTION
This adds the html_root attribute.

I added it directly above:

```rust
#![deny(missing_docs)]
```

as that seemed appropriate.