### PR TITLE
Note why `Handle` methods in `win` and `unix` won't panic

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -18,6 +18,8 @@ pub struct Handle {
 impl Drop for Handle {
     fn drop(&mut self) {
         if self.is_std {
+            // unwrap() will not panic. Since we were able to open an
+            // std stream successfully, then `file` is guaranteed to be Some()
             self.file.take().unwrap().into_raw_fd();
         }
     }
@@ -33,12 +35,16 @@ impl PartialEq for Handle {
 
 impl AsRawFd for ::Handle {
     fn as_raw_fd(&self) -> RawFd {
+        // unwrap() will not panic. Since we were able to open the
+        // file successfully, then `file` is guaranteed to be Some()
         self.0.file.as_ref().take().unwrap().as_raw_fd()
     }
 }
 
 impl IntoRawFd for ::Handle {
     fn into_raw_fd(mut self) -> RawFd {
+        // unwrap() will not panic. Since we were able to open the
+        // file successfully, then `file` is guaranteed to be Some()
         self.0.file.take().unwrap().into_raw_fd()
     }
 }
@@ -85,10 +91,14 @@ impl Handle {
     }
 
     pub fn as_file(&self) -> &File {
+        // unwrap() will not panic. Since we were able to open the
+        // file successfully, then `file` is guaranteed to be Some()
         self.file.as_ref().take().unwrap()
     }
 
     pub fn as_file_mut(&mut self) -> &mut File {
+        // unwrap() will not panic. Since we were able to open the
+        // file successfully, then `file` is guaranteed to be Some()
         self.file.as_mut().take().unwrap()
     }
 

--- a/src/win.rs
+++ b/src/win.rs
@@ -76,6 +76,8 @@ struct Key {
 impl Drop for Handle {
     fn drop(&mut self) {
         if self.is_std {
+            // unwrap() will not panic. Since we were able to open an
+            // std stream successfully, then `file` is guaranteed to be Some()
             self.file.take().unwrap().into_raw_handle();
         }
     }
@@ -94,12 +96,16 @@ impl PartialEq for Handle {
 
 impl AsRawHandle for ::Handle {
     fn as_raw_handle(&self) -> RawHandle {
+        // unwrap() will not panic. Since we were able to open the
+        // file successfully, then `file` is guaranteed to be Some()
         self.0.file.as_ref().take().unwrap().as_raw_handle()
     }
 }
 
 impl IntoRawHandle for ::Handle {
     fn into_raw_handle(mut self) -> RawHandle {
+        // unwrap() will not panic. Since we were able to open the
+        // file successfully, then `file` is guaranteed to be Some()
         self.0.file.take().unwrap().into_raw_handle()
     }
 }
@@ -171,10 +177,14 @@ impl Handle {
     }
 
     pub fn as_file(&self) -> &File {
+        // unwrap() will not panic. Since we were able to open the
+        // file successfully, then `file` is guaranteed to be Some()
         self.file.as_ref().take().unwrap()
     }
 
     pub fn as_file_mut(&mut self) -> &mut File {
+        // unwrap() will not panic. Since we were able to open the
+        // file successfully, then `file` is guaranteed to be Some()
         self.file.as_mut().take().unwrap()
     }
 }


### PR DESCRIPTION
As far as I can tell, the guarantee for `file` to be `Some()` is legit, so here goes.

Fixes #8 
