### PR TITLE
Allow users to use key independently from file handles.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ use unix as imp;
 #[cfg(windows)]
 use win as imp;
 
+pub use imp::Key;
+
 #[cfg(any(target_os = "redox", unix))]
 mod unix;
 #[cfg(windows)]
@@ -341,6 +343,13 @@ impl Handle {
     #[cfg(any(target_os = "redox", unix))]
     pub fn ino(&self) -> u64 {
         self.0.ino()
+    }
+
+    /// Return the underlying file key
+    ///
+    /// Key type depends on the platform
+    pub fn as_key(&self) -> Option<imp::Key> {
+        self.0.as_key()
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -5,14 +5,23 @@ use std::os::unix::fs::MetadataExt;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::path::Path;
 
+/// Low level key structure
+///
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub struct Key {
+    /// device number
+    dev: u64,
+    /// inode
+    ino: u64,
+}
+
 #[derive(Debug)]
 pub struct Handle {
     file: Option<File>,
     // If is_std is true, then we don't drop the corresponding File since it
     // will close the handle.
     is_std: bool,
-    dev: u64,
-    ino: u64,
+    key: Key,
 }
 
 impl Drop for Handle {
@@ -29,7 +38,7 @@ impl Eq for Handle {}
 
 impl PartialEq for Handle {
     fn eq(&self, other: &Handle) -> bool {
-        (self.dev, self.ino) == (other.dev, other.ino)
+        self.key == other.key
     }
 }
 
@@ -66,8 +75,10 @@ impl Handle {
         Ok(Handle {
             file: Some(file),
             is_std: false,
-            dev: md.dev(),
-            ino: md.ino(),
+            key: Key {
+                dev: md.dev(),
+                ino: md.ino(),
+            },
         })
     }
 
@@ -103,10 +114,14 @@ impl Handle {
     }
 
     pub fn dev(&self) -> u64 {
-        self.dev
+        self.key.dev
     }
 
     pub fn ino(&self) -> u64 {
-        self.ino
+        self.key.ino
+    }
+
+    pub fn as_key() -> Key {
+        Some(self.key.clone())
     }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -60,8 +60,7 @@ impl IntoRawFd for ::Handle {
 
 impl Hash for Handle {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.dev.hash(state);
-        self.ino.hash(state);
+        self.key.hash(state);
     }
 }
 
@@ -121,7 +120,7 @@ impl Handle {
         self.key.ino
     }
 
-    pub fn as_key() -> Key {
+    pub fn as_key(&self) -> Option<Key> {
         Some(self.key.clone())
     }
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -63,8 +63,10 @@ enum HandleKind {
     Borrowed(winutil::HandleRef),
 }
 
-#[derive(Debug, Eq, PartialEq, Hash)]
-struct Key {
+/// Low level key structure
+///
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub struct Key {
     volume: u64,
     index: u64,
 }
@@ -170,5 +172,9 @@ impl Handle {
             HandleKind::Owned(ref mut h) => h.as_file_mut(),
             HandleKind::Borrowed(ref mut h) => h.as_file_mut(),
         }
+    }
+
+    pub fn as_key(&self) -> Option<Key> {
+        self.key.clone()
     }
 }


### PR DESCRIPTION
Here's the use-case: I want to store a set of visited files, where the criteria of a file being unique is equivalent to `same-file`. However, using `HashSet<same_file::Handle>` will store handles to every visited file.

My solution to it is to allow users to extract file `Key`, which is supposedly a unique identifier.

Possible problems:
- This doesn't work for Windows stdio handles.  Which is irrelevant when traversing the file system.
- Theoretically, the fs can reuse inodes while I traverse the fs, so the criteria of uniqueness may be broken. Which is mostly irrelevant because the underlying fs can be manipulated so that tree traversal never ends.