### PR TITLE
add unknown module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,11 +79,15 @@ use std::path::Path;
 use unix as imp;
 #[cfg(windows)]
 use win as imp;
+#[cfg(not(any(target_os = "redox", unix, windows)))]
+use unknown as imp;
 
 #[cfg(any(target_os = "redox", unix))]
 mod unix;
 #[cfg(windows)]
 mod win;
+#[cfg(not(any(target_os = "redox", unix, windows)))]
+mod unknown;
 
 /// A handle to a file that can be tested for equality with other handles.
 ///

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::hash::{Hash, Hasher};
 use std::io;
 use std::path::Path;
 
@@ -8,21 +7,11 @@ static ERROR_MESSAGE: &str = "Unknown Architecture";
 #[derive(Debug)]
 pub struct Handle;
 
-impl Drop for Handle {
-    fn drop(&mut self) {
-    }
-}
-
 impl Eq for Handle {}
 
 impl PartialEq for Handle {
     fn eq(&self, _other: &Handle) -> bool {
         false
-    }
-}
-
-impl Hash for Handle {
-    fn hash<H: Hasher>(&self, _state: &mut H) {
     }
 }
 

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -2,8 +2,10 @@ use std::fs::File;
 use std::io;
 use std::path::Path;
 
-static ERROR_MESSAGE: &str = "Unknown Architecture";
-
+static ERROR_MESSAGE: &str = "same-file is not supported on this platform.";
+// This implementation is to allow same-file to be compiled on
+// unsupported platforms in case it was incidentally included
+// as a transitive, unused dependency
 #[derive(Debug)]
 pub struct Handle;
 
@@ -11,7 +13,7 @@ impl Eq for Handle {}
 
 impl PartialEq for Handle {
     fn eq(&self, _other: &Handle) -> bool {
-        false
+        unreachable!(ERROR_MESSAGE);
     }
 }
 
@@ -37,11 +39,11 @@ impl Handle {
     }
 
     pub fn as_file(&self) -> &File {
-        panic!(ERROR_MESSAGE);
+        unreachable!(ERROR_MESSAGE);
     }
 
     pub fn as_file_mut(&self) -> &mut File {
-        panic!(ERROR_MESSAGE);
+        unreachable!(ERROR_MESSAGE);
     }
 }
 

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -1,0 +1,61 @@
+use std::fs::File;
+use std::hash::{Hash, Hasher};
+use std::io;
+use std::path::Path;
+
+static ERROR_MESSAGE: &str = "Unknown Architecture";
+
+#[derive(Debug)]
+pub struct Handle;
+
+impl Drop for Handle {
+    fn drop(&mut self) {
+    }
+}
+
+impl Eq for Handle {}
+
+impl PartialEq for Handle {
+    fn eq(&self, _other: &Handle) -> bool {
+        false
+    }
+}
+
+impl Hash for Handle {
+    fn hash<H: Hasher>(&self, _state: &mut H) {
+    }
+}
+
+impl Handle {
+    pub fn from_path<P: AsRef<Path>>(_p: P) -> io::Result<Handle> {
+        error()
+    }
+
+    pub fn from_file(_file: File) -> io::Result<Handle> {
+        error()
+    }
+
+    pub fn stdin() -> io::Result<Handle> {
+        error()
+    }
+
+    pub fn stdout() -> io::Result<Handle> {
+        error()
+    }
+
+    pub fn stderr() -> io::Result<Handle> {
+        error()
+    }
+
+    pub fn as_file(&self) -> &File {
+        panic!(ERROR_MESSAGE);
+    }
+
+    pub fn as_file_mut(&self) -> &mut File {
+        panic!(ERROR_MESSAGE);
+    }
+}
+
+fn error<T>() -> io::Result<T> {
+    Err(io::Error::new(io::ErrorKind::Other, ERROR_MESSAGE))
+}


### PR DESCRIPTION
In reference to #42 this would allow for compilation on target architectures that are not windows, unix or redox. 

* Anywhere that a result is returned will now always return an error
* Anywhere a non-result is returned panics
* Error and panic messages are currently "Unknown Architecture" 
  * If you would like it to be more friendly please let me know and I can try and some up with something.
* The test I used was `cargo build --target wasm32-unknown-unknown` which worked
  * I can add this to the ci tests if you'd like