### PR TITLE
Reexport `Hash` impl for top-level `Handle`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ mod unknown;
 /// implementation details.
 ///
 /// [source]: https://github.com/BurntSushi/same-file/tree/master/src
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Hash)]
 pub struct Handle(imp::Handle);
 
 impl Handle {

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -6,7 +6,7 @@ static ERROR_MESSAGE: &str = "same-file is not supported on this platform.";
 // This implementation is to allow same-file to be compiled on
 // unsupported platforms in case it was incidentally included
 // as a transitive, unused dependency
-#[derive(Debug)]
+#[derive(Debug, Hash)]
 pub struct Handle;
 
 impl Eq for Handle {}


### PR DESCRIPTION
This looks like it may have been intended in #17 but slipped through by
accident?