### PR TITLE
Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ See [`examples/is_stderr.rs`] for a runnable example and compare the output of:
 #![allow(bare_trait_objects, unknown_lints)]
 #![deny(missing_docs)]
 
-#[cfg(test)]
+#[cfg(doctest)]
 doc_comment::doctest!("../README.md");
 
 use std::fs::File;


### PR DESCRIPTION
Rustdoc now passes "doctest" when running in test mode.